### PR TITLE
[dart-dio] Use sourceFolder property instead of src

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/analysis_options.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/analysis_options.mustache
@@ -7,6 +7,6 @@ analyzer:
     implicit-casts: false
   exclude:
     - test/*.dart{{#useJsonSerializable}}
-    - lib/src/model/*.g.dart{{/useJsonSerializable}}
+    - lib/{{sourceFolder}}/model/*.g.dart{{/useJsonSerializable}}
   errors:
     deprecated_member_use_from_same_package: ignore

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/api/imports.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/api/imports.mustache
@@ -1,3 +1,3 @@
 // ignore: unused_import
 import 'dart:convert';
-import 'package:{{pubName}}/src/deserialize.dart';
+import 'package:{{pubName}}/{{sourceFolder}}/deserialize.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: unused_import
 import 'dart:convert';
 import 'package:openapi/src/deserialize.dart';
+
 import 'package:dio/dio.dart';
 
 import 'package:openapi/src/model/model_client.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/default_api.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: unused_import
 import 'dart:convert';
 import 'package:openapi/src/deserialize.dart';
+
 import 'package:dio/dio.dart';
 
 import 'package:openapi/src/model/foo_get_default_response.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: unused_import
 import 'dart:convert';
 import 'package:openapi/src/deserialize.dart';
+
 import 'package:dio/dio.dart';
 
 import 'package:openapi/src/model/file_schema_test_class.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: unused_import
 import 'dart:convert';
 import 'package:openapi/src/deserialize.dart';
+
 import 'package:dio/dio.dart';
 
 import 'package:openapi/src/model/model_client.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: unused_import
 import 'dart:convert';
 import 'package:openapi/src/deserialize.dart';
+
 import 'package:dio/dio.dart';
 
 import 'package:openapi/src/model/api_response.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: unused_import
 import 'dart:convert';
 import 'package:openapi/src/deserialize.dart';
+
 import 'package:dio/dio.dart';
 
 import 'package:openapi/src/model/order.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: unused_import
 import 'dart:convert';
 import 'package:openapi/src/deserialize.dart';
+
 import 'package:dio/dio.dart';
 
 import 'package:openapi/src/model/user.dart';


### PR DESCRIPTION
The dart-dio generator had a couple of hard-coded `/src/` paths which meant the resulting code didn't work if you used a the custom `sourceFolder` property as it was importing from a directory that didn't exist.

This change results in no differences in the generated code (although a new line got added when I ran the scripts in the instructions so I've committed that) since the default source directory is already `src`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
